### PR TITLE
Corrected casing of 'S' character of <hotSpot> element to follow KML …

### DIFF
--- a/renderer/mil-sym-renderer/src/main/java/sec/web/renderer/SECRenderer.java
+++ b/renderer/mil-sym-renderer/src/main/java/sec/web/renderer/SECRenderer.java
@@ -952,7 +952,7 @@ public class SECRenderer {
                             kml.append("<Icon>");
                                 kml.append("<href><![CDATA[" + fullURL.replaceAll("kml", "image") + "]]></href>");
                             kml.append("</Icon>");
-                            kml.append("<hotspot x=\"" + String.valueOf(pi.getCenterPoint().getX()) + 
+                            kml.append("<hotSpot x=\"" + String.valueOf(pi.getCenterPoint().getX()) + 
                                              "\" y=\"" + String.valueOf(pi.getCenterPoint().getY()) +
                                              "\" xunits=\"pixels\" yunits=\"insetPixels\"/>");
                         kml.append("</IconStyle>");


### PR DESCRIPTION
…specification: https://developers.google.com/kml/documentation/kmlreference.