### PR TITLE
removed hotSpot element to center icon over its location

### DIFF
--- a/renderer/mil-sym-renderer/src/main/java/sec/web/renderer/SECRenderer.java
+++ b/renderer/mil-sym-renderer/src/main/java/sec/web/renderer/SECRenderer.java
@@ -952,9 +952,6 @@ public class SECRenderer {
                             kml.append("<Icon>");
                                 kml.append("<href><![CDATA[" + fullURL.replaceAll("kml", "image") + "]]></href>");
                             kml.append("</Icon>");
-                            kml.append("<hotSpot x=\"" + String.valueOf(pi.getCenterPoint().getX()) + 
-                                             "\" y=\"" + String.valueOf(pi.getCenterPoint().getY()) +
-                                             "\" xunits=\"pixels\" yunits=\"insetPixels\"/>");
                         kml.append("</IconStyle>");
                         kml.append("<LabelStyle>");
                             kml.append("<scale>" + "0" + "</scale>");


### PR DESCRIPTION
After fixing the capitalization error (hotspot vs hotSpot), we saw kml icons being displayed way out into space.  We decided that we preferred having the icons centered over its location and removed the hotSpot element.  The kmls now look like they used to before the capitalization fix, when the renderers simply ignored the incorrectly capitalized hotspot.