### PR TITLE
#81 - The behavior is expected and it is by design. I enhanced the reindeer by

### DIFF
--- a/core/JavaLineArray/src/main/java/JavaTacticalRenderer/Modifier2.java
+++ b/core/JavaLineArray/src/main/java/JavaTacticalRenderer/Modifier2.java
@@ -1925,27 +1925,71 @@ public class Modifier2 {
 
             int stringWidth = metrics.stringWidth(label);
             boolean foundLongSegment = false;
+            int n = tg.Pixels.size();
             double dist = 0;
             POINT2 pt0 = null, pt1 = null;
+            
+            int northestPtIndex = 0;
+    		int southestPtIndex = 0;
+    		POINT2 northestPt = null;
+    		POINT2 southestPt = null;
 
-            for (j = startIndex; j < tg.Pixels.size() - 1; j++) {
-                pt0 = tg.Pixels.get(j);
-                pt1 = tg.Pixels.get(j + 1);
-                dist = lineutility.CalcDistanceDouble(pt0, pt1);
-                if (dist > 1.5 * stringWidth) {
-                    foundLongSegment = true;
-                    AddIntegralAreaModifier(tg, label, aboveMiddle, 0, pt0, pt1, true);
-                }
+    		//acevedo - 11/14/2017 - adding option to render only 2 ENY labels.
+            if (RendererSettings.getInstance().getTwoENYLabelOnly() == false) {
+            
+	            //for (j = startIndex; j < tg.Pixels.size() - 1; j++) 
+	            for (j = startIndex; j < n - 1; j++) {
+	                pt0 = tg.Pixels.get(j);
+	                pt1 = tg.Pixels.get(j + 1);
+	                dist = lineutility.CalcDistanceDouble(pt0, pt1);
+	                if (dist > 1.5 * stringWidth) {
+	                    foundLongSegment = true;
+	                    AddIntegralAreaModifier(tg, label, aboveMiddle, 0, pt0, pt1, true);
+	                }
+	            }
+	            if (foundLongSegment == false)//we did not find a long enough segment
+	            {
+	                if (middleSegment != startIndex) {
+	                    AddIntegralModifier(tg, label, aboveMiddle, 0, middleSegment, middleSegment + 1, true);
+	                }
+	                AddIntegralModifier(tg, label, aboveMiddle, 0, middleSegment2, middleSegment2 + 1, true);
+	
+	            }
             }
-            if (foundLongSegment == false)//we did not find a long enough segment
-            {
-                if (middleSegment != startIndex) {
-                    AddIntegralModifier(tg, label, aboveMiddle, 0, middleSegment, middleSegment + 1, true);
-                }
+            else {
+                // 2 ENY labels one to the north and the other to the south of graphic.
+                for (j = startIndex; j < n - 1; j++) {
+                    pt0 = tg.Pixels.get(j);
 
+        			if (northestPt == null)
+        			{
+        				northestPt = pt0;
+        				northestPtIndex = j;
+        			}
+        			if (southestPt == null)
+        			{
+        				southestPt = pt0;
+        				southestPtIndex = j;
+        			}
+        			if (pt0.y >= northestPt.y)
+        			{
+        				northestPt = pt0;
+        				northestPtIndex = j;
+        			}
+
+        			if (pt0.y <= southestPt.y)
+        			{
+        				southestPt = pt0;
+        				southestPtIndex = j;
+        			}
+                }//for
+
+        		middleSegment = northestPtIndex;
+        		middleSegment2 = southestPtIndex;
+                if (middleSegment != startIndex)
+                	AddIntegralModifier(tg, label, aboveMiddle, 0, middleSegment, middleSegment + 1, true);
                 AddIntegralModifier(tg, label, aboveMiddle, 0, middleSegment2, middleSegment2 + 1, true);
-
-            }
+            }//else
         } catch (Exception exc) {
             ErrorLogger.LogException(_className, "areasWithENY",
                     new RendererException("Failed inside areasWithENY", exc));

--- a/core/JavaRendererUtils/src/main/java/ArmyC2/C2SD/Utilities/RendererSettings.java
+++ b/core/JavaRendererUtils/src/main/java/ArmyC2/C2SD/Utilities/RendererSettings.java
@@ -138,6 +138,9 @@ public class RendererSettings {
     private static float _KMLLabelScale = 1.0f;
     
     private static int _DPI = 90;
+    
+    //acevedo - 11/14/2017 - adding option to render only 2 ENY labels.
+    private boolean _TwoENYLabelOnly = true;
 
     private RendererSettings()
     {
@@ -698,5 +701,27 @@ public class RendererSettings {
     {
         return _KMLLabelScale;
     }
+    
+    
+    /**
+  	 ** Get a boolean indicating between the use of ENY labels in all segments (false) or 
+ 	 * to only set 2 labels one at the north and the other one at the south of the graphic (true).
+  	 * @returns {boolean}
+  	 */
+  	public boolean getTwoENYLabelOnly()
+  	{
+  			return _TwoENYLabelOnly;
+  	}
+  	
+  	/**
+ 	 * Set a boolean indicating between the use of ENY labels in all segments (false) or 
+ 	 * to only set 2 labels one at the north and the other one at the south of the graphic (true).
+ 	 * @param TwoENYLabelOnly
+ 	 */
+ 	public void setTwoENYLabelOnly(boolean TwoENYLabelOnly )
+ 	{
+ 		_TwoENYLabelOnly = TwoENYLabelOnly;
+ 	}
+ 	
 
 }


### PR DESCRIPTION
adding an option to display ENY labels in all segments, or to only
display the label 2 times, one in the north and the other one in the
south of the hostile graphics that display ENY.