### PR TITLE
Include SOF units in `isUnit`

### DIFF
--- a/core/JavaRendererUtils/src/main/java/ArmyC2/C2SD/Utilities/SymbolUtilities.java
+++ b/core/JavaRendererUtils/src/main/java/ArmyC2/C2SD/Utilities/SymbolUtilities.java
@@ -2894,10 +2894,10 @@ public class SymbolUtilities {
   {
     try
     {
-      boolean isGrounUnit = ((strSymbolID.substring(0, 1).equals("S")) && 
+      boolean isGroundUnit = ((strSymbolID.substring(0, 1).equals("S")) && 
                             (strSymbolID.substring(2, 3).equals("G")) &&
                             (strSymbolID.substring(4,5).equals("U")));
-      return isGrounUnit || isSOF(strSymbolID);
+      return isGroundUnit || isSOF(strSymbolID);
     }
     catch(Throwable t)
     {

--- a/core/JavaRendererUtils/src/main/java/ArmyC2/C2SD/Utilities/SymbolUtilities.java
+++ b/core/JavaRendererUtils/src/main/java/ArmyC2/C2SD/Utilities/SymbolUtilities.java
@@ -2894,10 +2894,10 @@ public class SymbolUtilities {
   {
     try
     {
-      boolean blRetVal = ((strSymbolID.substring(0, 1).equals("S")) && 
+      boolean isGrounUnit = ((strSymbolID.substring(0, 1).equals("S")) && 
                             (strSymbolID.substring(2, 3).equals("G")) &&
                             (strSymbolID.substring(4,5).equals("U")));
-      return blRetVal;
+      return isGrounUnit || isSOF(strSymbolID);
     }
     catch(Throwable t)
     {


### PR DESCRIPTION
The comment for `isUnit` says it should return true for SOF units. This is currently preventing SOF units from having echelon marks.