### PR TITLE
additional null check for the Higher Formation modifier

### DIFF
--- a/core/JavaRenderer/src/main/java/ArmyC2/C2SD/Rendering/SinglePointRenderer.java
+++ b/core/JavaRenderer/src/main/java/ArmyC2/C2SD/Rendering/SinglePointRenderer.java
@@ -3206,7 +3206,7 @@ public class SinglePointRenderer {
                 modifierValue += mValue;
                 if(ccValue != null)
                 {
-                    if(mValue.equals("") == false)
+                    if(mValue != null && mValue.equals("") == false)
                         modifierValue += " ";
                     modifierValue += ccValue;
                 }


### PR DESCRIPTION
When rendering a unit (eg, SHGPUCF---EETUG) where there is a `CC_COUNTRY_CODE` and the unit _can_ have a `M_HIGHER_FORMATION` modifier but does not, mValue gets set to `null` and then causes a NullPointerException when trying to compare it to the empty string.

There are a half dozen different ways to code this fix, I went with minimally disruptive. If you have a different stylistic preference I'm happy to amend!