### PR TITLE
check for null before adding M_HIGHER_FORMATION to modifier string

### DIFF
--- a/core/JavaRenderer/src/main/java/ArmyC2/C2SD/Rendering/SinglePointRenderer.java
+++ b/core/JavaRenderer/src/main/java/ArmyC2/C2SD/Rendering/SinglePointRenderer.java
@@ -3202,8 +3202,9 @@ public class SinglePointRenderer {
                 if(SymbolUtilities.canUnitHaveModifier(symbolID, ModifiersUnits.M_HIGHER_FORMATION))
                     mValue = modifiers.get(ModifiersUnits.M_HIGHER_FORMATION);
                 String ccValue = modifiers.get(ModifiersUnits.CC_COUNTRY_CODE);
-                
-                modifierValue += mValue;
+
+                if(mValue != null)
+                    modifierValue += mValue;
                 if(ccValue != null)
                 {
                     if(mValue != null && mValue.equals("") == false)


### PR DESCRIPTION
If a unit _can_ have a Higher Formation modifier but does not, you end up with `null` in the symbol. EG, `SHGPUCF----EAF-` results in 
![test](https://user-images.githubusercontent.com/39965329/44039057-3d8cdc6c-9ee6-11e8-9c24-3ed0902fadbd.png)